### PR TITLE
Fix invalid, unnecessary XHTML vestiges in root element

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en-us">
+<html{{ with .Site.LanguageCode }} lang="{{ . }}"{{ end }}>
 <head>
   <link href="http://gmpg.org/xfn/11" rel="profile">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
If `xml:lang` is kept, `lang` must also be used *and they must be
exactly the same*. This was failing validation out of the box.

The `xmlns` and `xml:lang` are no longer needed for HTML5:

    http://diveintohtml5.info/semantics.html#html-element

Finally, Hugo has a `languageCode` config setting, let's use it.